### PR TITLE
Changing to a C linkage interface

### DIFF
--- a/ndicapi.cxx
+++ b/ndicapi.cxx
@@ -2490,7 +2490,7 @@ ndicapiExport int ndiGetPHSRInformation(ndicapi* pol, int i)
 }
 
 //----------------------------------------------------------------------------
-ndicapiExport int ndiGetTXTransform(ndicapi* pol, int portHandle, float transform[8])
+ndicapiExport int ndiGetTXTransformf(ndicapi* pol, int portHandle, float transform[8])
 {
   char* readPointer;
   int i, n;

--- a/ndicapi.h
+++ b/ndicapi.h
@@ -945,7 +945,7 @@ ndicapiExport int ndiGetPHINFGPIOStatus(ndicapi* pol);
   The transformations for each of the port handles remain the same
   until the next TX command is sent to device.
 */
-ndicapiExport int ndiGetTXTransform(ndicapi* pol, int portHandle, float transform[8]);
+ndicapiExport int ndiGetTXTransformf(ndicapi* pol, int portHandle, float transform[8]);
 ndicapiExport int ndiGetTXTransform(ndicapi* pol, int portHandle, double transform[8]);
 
 /*! \ingroup GetMethods
@@ -1370,7 +1370,7 @@ marker.
 <p>The stray marker position is only updated when the BX command is
 called with the NDI_SINGLE_STRAY (0x0004) bit set.
 */
-ndicapiExport int ndiGetBXSingleStray(ndicapi* pol, int portHandle, double coord[3]);
+ndicapiExport int ndiGetBXSingleStray(ndicapi* pol, int portHandle, float coord[3]);
 
 /*! \ingroup GetMethods
 Get the number of passive stray markers detected.
@@ -1401,7 +1401,7 @@ markers that are visible.
 The passive stray marker coordinates are updated when a BX command
 is sent with the NDI_PASSIVE_STRAY (0x1000) bit set in the reply mode.
 */
-ndicapiExport int ndiGetBXPassiveStray(ndicapi* pol, int i, double coord[3]);
+ndicapiExport int ndiGetBXPassiveStray(ndicapi* pol, int i, float coord[3]);
 
 /*! \ingroup GetMethods
 Get an 16-bit status bitfield for the system.

--- a/ndicapiExport.h.in
+++ b/ndicapiExport.h.in
@@ -16,7 +16,7 @@
 
 #if defined(WIN32) && !defined(ndicapi_STATIC)
  #if defined(ndicapi_EXPORTS)
-  #define ndicapiExport __declspec( dllexport )
+  #define ndicapiExport extern "C" __declspec( dllexport )
  #else
   #define ndicapiExport __declspec( dllimport )
  #endif

--- a/ndicapi_math.cxx
+++ b/ndicapi_math.cxx
@@ -147,7 +147,7 @@ ndicapiExport void ndiTransformToMatrixf(const float trans[8], float matrix[16])
 }
 
 //----------------------------------------------------------------------------
-ndicapiExport void ndiTransformToMatrixd(const float trans[8], double matrix[16])
+ndicapiExport void ndiTransformToMatrixfd(const float trans[8], double matrix[16])
 {
   double ww, xx, yy, zz, wx, wy, wz, xy, xz, yz, ss, rr, f;
 

--- a/ndicapi_math.h
+++ b/ndicapi_math.h
@@ -79,7 +79,7 @@ ndicapiExport void ndiTransformToMatrixf(const float trans[8], float matrix[16])
 /*! \ingroup NdicapiMath
   Convert a quaternion transformation into a 4x4 double matrix.
 */
-ndicapiExport void ndiTransformToMatrixd(const float trans[8], double matrix[16]);
+ndicapiExport void ndiTransformToMatrixfd(const float trans[8], double matrix[16]);
 /*! \ingroup NdicapiMath
 Convert a quaternion transformation into a 4x4 double matrix.
 */


### PR DESCRIPTION
Hi Adam. These are the minimum changes that allow a C linkage interface for ndicapi.
Since these are interface changes, I'm worried about the consequences on ndicapi dependent projects. In particular we have to be careful about the following: 

1. I had to change two function names that were using C++ overloading. These were functions that had a fload and a double version. I noticed that in other functions the distinction was made with the name last letter convention (f or d), so I followed the same convention.

2. There were two functions that were declared with a double array parameter but which were implemented only with a float array parameter. I think these functions are never actually used, because they would throw an "undefined symbol" linking error if they were called from external code. In this case I changed the declared double to float, because I noticed that the implementation actually expected float values (it is using the sizeof floats instead of doubles).  

Please let me know if you want to discuss these changes further. I will ask permission to my employer to publish the ndidotnetapi in which I am working.

Thanks!

Federico