### PR TITLE
repaired TXHelper (strayCount) and ndiGetTXPassiveStray

### DIFF
--- a/ndicapi.cxx
+++ b/ndicapi.cxx
@@ -1250,7 +1250,7 @@ namespace
     if (mode & NDI_PASSIVE_STRAY)
     {
       // get the number of strays
-      strayCount = (int)ndiSignedToLong(commandReply, 3);
+      strayCount = (int)ndiHexToUnsignedLong(commandReply, 2);
       for (j = 0; j < 2 && *commandReply >= ' '; j++)
       {
         commandReply++;
@@ -2721,7 +2721,7 @@ ndicapiExport int ndiGetTXPassiveStray(ndicapi* pol, int i, double coord[3])
   }
 
   n = pol->TxPassiveStrayCount;
-  dp += 3;
+  //dp += 3;
   if (n < 0)
   {
     return NDI_MISSING;


### PR DESCRIPTION
Wrong parsing the number of strays from commandReply in TXHelper (should parse only 2 first signs, signs are hex).
Also unnecessary dp += 3 in ndiGetTXPassiveStray -- prevents correctful data reading.