### PR TITLE
maximum number of passive stray markers to track

### DIFF
--- a/ndicapi.cxx
+++ b/ndicapi.cxx
@@ -2721,7 +2721,6 @@ ndicapiExport int ndiGetTXPassiveStray(ndicapi* pol, int i, double coord[3])
   }
 
   n = pol->TxPassiveStrayCount;
-  //dp += 3;
   if (n < 0)
   {
     return NDI_MISSING;

--- a/ndicapi.cxx
+++ b/ndicapi.cxx
@@ -2725,9 +2725,9 @@ ndicapiExport int ndiGetTXPassiveStray(ndicapi* pol, int i, double coord[3])
   {
     return NDI_MISSING;
   }
-  if (n > 20)
+  if (n > 50)
   {
-    n = 20;
+    n = 50;
   }
 
   if (i < 0 || i >= n)

--- a/ndicapi.h
+++ b/ndicapi.h
@@ -1041,7 +1041,7 @@ ndicapiExport int ndiGetTXSingleStray(ndicapi* pol, int ph, double coord[3]);
   Get the number of passive stray markers detected.
 
   \param pol       valid NDI device handle
-  \return          a number between 0 and 20
+  \return          a number between 0 and 50
 
   The passive stray marker coordinates are updated when a TX command
   is sent with the NDI_PASSIVE_STRAY (0x1000) bit set in the reply mode.
@@ -1053,7 +1053,7 @@ ndicapiExport int ndiGetTXNumberOfPassiveStrays(ndicapi* pol);
   supplied array.
 
   \param pol       valid NDI device handle
-  \param i         a number between 0 and 19
+  \param i         a number between 0 and 49
   \param coord     array to hold the coordinates
   \return          one of:
   - NDI_OKAY - information was returned in coord


### PR DESCRIPTION
Hi,
I've just noticed that ndiGetTXPassiveStray limits max number of tracked strays to 20. According to NDI Polaris manual, Polaris allows tracking up to 50 passive strays. Also TXHelper limits StrayCount to 50, not 20, so I wonder if it was just overlooked or maybe there's some reason for limiting max number of strays to track. This change isn't tested since I don't have free access to Polaris system lately (also checking more than 20 strays probably will be impossible for me anyway, unless I could manage producing phantoms somehow).