### PR TITLE
Issue #24 we don't need a 2 dimonsional array for devicenames

### DIFF
--- a/ndicapi.cxx
+++ b/ndicapi.cxx
@@ -631,7 +631,7 @@ ndicapiExport const char* ndiSerialDeviceName(int i)
 #elif defined (__APPLE__)
 
   // Apple
-  static char devicenames[4][255 + 6];
+  static char devicename[255 + 6];
   DIR* dirp;
   struct dirent* ep;
   int j = 0;
@@ -642,18 +642,18 @@ ndicapiExport const char* ndiSerialDeviceName(int i)
     return NULL;
   }
 
-  while ((ep = readdir(dirp)) != NULL && j < 4)
+  while ((ep = readdir(dirp)) != NULL && j < i+1)
   {
     if (ep->d_name[0] == 'c' && ep->d_name[1] == 'u' &&
         ep->d_name[2] == '.')
     {
       if (j == i)
       {
-        strncpy(devicenames[j], "/dev/", 5);
-        strncpy(devicenames[j] + 5, ep->d_name, 255);
-        devicenames[j][255 + 5] = '\0';
+        strncpy(devicename, "/dev/", 5);
+        strncpy(devicename + 5, ep->d_name, 255);
+        devicename[255 + 5] = '\0';
         closedir(dirp);
-        return devicenames[j];
+        return devicename;
       }
       j++;
     }


### PR DESCRIPTION
I couldn't see that having an array of device names was necessary, as it only gets written to if i==j, so I've just changed the devicename to a 1 dimensional array and continue the while loop until j<i+1. 
It seems to work for me [see here](https://github.com/UCL/scikit-surgerynditracker/actions)