### PR TITLE
Fix to extend the range of COM-ports that ndicapi can handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package provides a portable C library that provides a straightforward inter
 The contents of this package have been built successfully under a wide range of compilers. It is a [CMake](https://cmake.org/download/) project and can be configured and built as such.
 
 ## Building
-To build, configure first using CMake, then build according to your chosen generator.
+To build, configure first using CMake, build according to your chosen generator. [Instructions on how to do this here.](https://preshing.com/20170511/how-to-build-a-cmake-based-project/) 
 
 ### Python
 To build the [Python][python] extension module of this library:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package provides a portable C library that provides a straightforward inter
 The contents of this package have been built successfully under a wide range of compilers. It is a [CMake](https://cmake.org/download/) project and can be configured and built as such.
 
 ## Building
-To build, configure first using CMake, build according to your chosen generator. [Instructions on how to do this here.](https://preshing.com/20170511/how-to-build-a-cmake-based-project/) 
+To build, configure first using CMake, then build according to your chosen generator. [Instructions on how to do this here.](https://preshing.com/20170511/how-to-build-a-cmake-based-project/) 
 
 ### Python
 To build the [Python][python] extension module of this library:


### PR DESCRIPTION
Written to address issue #31. 

This code extracts the number of the COM port by deleting the first three characters, then converting the remainder into an integer. If that integer is greater than 9, opens a port using "\\\\.\\COMn" if that integer is less than 9 it opens a port using "COMn".