### PR TITLE
Issue #12 add pre-processor commands to build on python 3.12

### DIFF
--- a/ndicapimodule.cxx
+++ b/ndicapimodule.cxx
@@ -26,7 +26,11 @@
   #define PyString_AsString PyUnicode_AsUTF8
   #define PyIntObject PyLongObject
   //#define PY_INT_OBJECT_OB_IVAL(ob) PyLong_AsLong((PyObject*)(ob))
-  #define PY_INT_OBJECT_OB_IVAL(ob) ob->ob_digit[0]
+  #if PY_MINOR_VERSION < 12
+    #define PY_INT_OBJECT_OB_IVAL(ob) ob->ob_digit[0]
+  #else
+    #define PY_INT_OBJECT_OB_IVAL(ob) ob->long_value.ob_digit[0]
+  #endif
   #define cmpfunc PyAsyncMethods*
 #else
   #define MOD_ERROR_VAL


### PR DESCRIPTION
Fixes https://github.com/PlusToolkit/ndicapi/issues/43.
This builds on all versions of Python for me and shouldn't affect existing Python versions. See build log:
https://github.com/SciKit-Surgery/ndicapi/actions/runs/8002962485

I haven't been able to actually plug in a tracker and make sure it physically gets tracking data though. 
I also don't really understand what's going on inside Cpython / cython, my fix is based on this https://github.com/cython/cython/issues/5238